### PR TITLE
test: Cobertura de sad path para ausência do campo equation

### DIFF
--- a/tests/mobile_bff/api/v1/test_equations_route.py
+++ b/tests/mobile_bff/api/v1/test_equations_route.py
@@ -139,6 +139,12 @@ class SolveEquationRouteTests(unittest.TestCase):
         self.assertEqual(body["result"], "2.5")
         self.assertEqual(body["steps"], [])
 
+def test_rejects_missing_equation_field(self) -> None:
+        response = self.client.post(
+            "/v1/equation/solve",
+            json={"showSteps": True}, 
+        )
+        self.assertEqual(response.status_code, 422)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adicionado um teste no arquivo test_equations_route.py para verificar o comportamento da API quando o usuário esquece de enviar o campo "equation". O teste garante que o sistema está bloqueando a requisição corretamente com o erro 422